### PR TITLE
restrict sphinx below 8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx
+sphinx < 8.0
 sphinx_rtd_theme
 myst_nb
 sphinx-lesson


### PR DESCRIPTION
- page does currently not build with recently released sphinx 8.0
- a nicer solution would be to fix the problems but I need to focus on other things now