### PR TITLE
Add timezone conversion

### DIFF
--- a/content/conf.py
+++ b/content/conf.py
@@ -39,6 +39,7 @@ extensions = [
     'sphinx_rtd_theme_ext_color_contrast',
     'sphinx_coderefinery_branding',
     'sphinxcontrib.youtube',
+    'sphinx_localtime',
 ]
 
 myst_enable_extensions = [

--- a/content/index.md
+++ b/content/index.md
@@ -38,7 +38,9 @@ Facilitators and instructors:
 
 **Content and timing:**
 
-The workshop consists of four sessions every Tuesday between August 13th and September 3rd 2024, 9-12 Central European Summer Time (CEST; UTC +2):
+The workshop consists of four sessions every Tuesday between August
+13th and September 3rd 2024, {localtime}`09:00 13 August 2024 +02:00 (HH:mm
+z/zzz)`:
 
 - Session 1: About lesson design, deployment and iterative improvement (Aug 13)
 - Session 2: Tools and techniques adopted in CodeRefinery workshops (Aug 20)

--- a/content/index.md
+++ b/content/index.md
@@ -39,8 +39,9 @@ Facilitators and instructors:
 **Content and timing:**
 
 The workshop consists of four sessions every Tuesday between August
-13th and September 3rd 2024, {localtime}`09:00 13 August 2024 +02:00 (HH:mm
-z/zzz)`:
+13th and September 3rd 2024,
+{localtime}`09:00 13 August 2024 +02:00 (HH:mm)` to
+{localtime}`12:00 13 August 2024 +02:00 (HH:mm z/zzz)`:
 
 - Session 1: About lesson design, deployment and iterative improvement (Aug 13)
 - Session 2: Tools and techniques adopted in CodeRefinery workshops (Aug 20)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ sphinx-design
 sphinx_rtd_theme_ext_color_contrast
 https://github.com/coderefinery/sphinx-coderefinery-branding/archive/master.zip
 https://github.com/rkdarst/sphinx-contrib-youtube/archive/live.zip
+https://github.com/coderefinery/sphinx-localtime/archive/main.zip


### PR DESCRIPTION
- `CEST` was the first instance I saw of a short name that didn't
  work, leading to mass problems.  +02:00 seems the best compromise
  for now.

- For me this renders as:

  The workshop consists of four sessions every Tuesday between August
  13th and September 3rd 2024, 10:00 GMT+3/Eastern European Summer
  Time:
